### PR TITLE
Change absolute path to relative path to work in different installations

### DIFF
--- a/dirty_image_2sources.py
+++ b/dirty_image_2sources.py
@@ -77,7 +77,7 @@ if 1:
     """
     Read antenna positions from ASCII file (XYZ, meters)
     """
-    vlas=numpy.genfromtxt("/home/vlad/software/SKA/crocodile/test/VLA_A_hor_xyz_5ants.txt", delimiter=",")
+    vlas=numpy.genfromtxt("test/VLA_A_hor_xyz_5ants.txt", delimiter=",")
     plot_scatter(vlas[:,0], vlas[:,1], 'Antenna positions on the (X,Y) plane', 'X, meters', 'Y, meters')
 
 


### PR DESCRIPTION
This fixes an issue when trying to use the software on a different machine, by using a relative path to where the script is written.